### PR TITLE
Add Aloodo un-tracking pixel

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,5 +103,6 @@ This site is maintained in a <a href="https://github.com/fmarier/fmarier.org">pu
 </div>
 
 </div>
+<img src="https://ad.aloodo.com/px/fmarier.org/" alt="" height="1" width="1">
 </body>
 </html>


### PR DESCRIPTION
Pre-set an Aloodo cookie containing `fmarier.org`,
to help prime the script that appears on
`feeding.cloud.geek.nz`.

This pixel should be served with a long `Expires`
time in order to minimize network traffic even for
unprotected users.

More info: http://blog.aloodo.org/misc/howto/#pixel
